### PR TITLE
Return defensive copies of TSet from the HQDM methods.

### DIFF
--- a/src/HQDM.ts
+++ b/src/HQDM.ts
@@ -527,7 +527,7 @@ export class HQDMModel {
    * @returns the classes that the thing is a member of.
    */
   memberOf(t: Thing): TSet<Thing> {
-    return this.getRelated(t, MEMBER_OF);
+    return this.getRelated(t, MEMBER_OF).clone();
   }
 
   /**
@@ -537,7 +537,7 @@ export class HQDMModel {
    * @returns the kinds that the thing is a member of.
    */
   memberOfKind(t: Thing): TSet<Thing> {
-    return this.getRelated(t, MEMBER_OF_KIND);
+    return this.getRelated(t, MEMBER_OF_KIND).clone();
   }
 
   /**

--- a/src/HQDM.ts
+++ b/src/HQDM.ts
@@ -114,7 +114,7 @@ export class HQDMModel {
    * @kind the type of object to find.
    * @returns the objects if found, an empty array otherwise.
    */
-  findByType(kind: Thing): Thing[] {
+  findByType(kind: Thing): Iterable<Thing> {
     const result: Thing[] = [];
     this.relations.get(RDF_TYPE)?.forEach((p) => {
       if (p.r.equal(kind)) {
@@ -144,7 +144,7 @@ export class HQDMModel {
    * @param communityName the community to get the signs for.
    * @returns the signs for the thing.
    */
-  getIdentifications(t: Thing, communityName: Thing): SpatioTemporalExtent[] {
+  getIdentifications(t: Thing, communityName: Thing): Iterable<SpatioTemporalExtent> {
     return this.getSignsOfKind(t, communityName, identification);
   }
 
@@ -154,7 +154,7 @@ export class HQDMModel {
    * @param t should be an activity Thing.
    * @returns the participants for the activity.
    */
-  getParticipants(t: Thing): Thing[] {
+  getParticipants(t: Thing): Iterable<Thing> {
     const result: Thing[] = [];
     this.relations
       .get(PARTICIPANT_IN)
@@ -181,7 +181,7 @@ export class HQDMModel {
    * @param communityName the community to get the descriptions for.
    * @returns the descriptions for the thing.
    */
-  getDescriptions(t: Thing, communityName: Thing): SpatioTemporalExtent[] {
+  getDescriptions(t: Thing, communityName: Thing): Iterable<SpatioTemporalExtent> {
     return this.getSignsOfKind(t, communityName, description);
   }
 
@@ -191,7 +191,7 @@ export class HQDMModel {
    * @param t the thing to get the roles for.
    * @returns the roles for the thing.
    */
-  getRole(t: Thing): Thing[] {
+  getRole(t: Thing): Iterable<Thing> {
     const result: Thing[] = [];
     this.relations
       .get(MEMBER_OF_KIND)
@@ -213,7 +213,7 @@ export class HQDMModel {
     t: Thing,
     communityName: Thing,
     kind: Thing
-  ): SpatioTemporalExtent[] {
+  ): Iterable<SpatioTemporalExtent> {
     const result: Thing[] = [];
 
     // Find the community.
@@ -526,8 +526,8 @@ export class HQDMModel {
    * @param t the thing to find the classes for.
    * @returns the classes that the thing is a member of.
    */
-  memberOf(t: Thing): TSet<Thing> {
-    return this.getRelated(t, MEMBER_OF).clone();
+  memberOf(t: Thing): Iterable<Thing> {
+    return this.getRelated(t, MEMBER_OF);
   }
 
   /**
@@ -536,8 +536,8 @@ export class HQDMModel {
    * @param t the thing to find the kinds for.
    * @returns the kinds that the thing is a member of.
    */
-  memberOfKind(t: Thing): TSet<Thing> {
-    return this.getRelated(t, MEMBER_OF_KIND).clone();
+  memberOfKind(t: Thing): Iterable<Thing> {
+    return this.getRelated(t, MEMBER_OF_KIND);
   }
 
   /**
@@ -548,7 +548,7 @@ export class HQDMModel {
    * @returns true if the thing is a member of the kind.
    */
   isKindOf(t: Thing, k: Thing): boolean {
-    return this.getRelated(t, MEMBER_OF_KIND).has(k);
+    return this._getRelated(t, MEMBER_OF_KIND).has(k);
   }
 
   /**
@@ -559,7 +559,7 @@ export class HQDMModel {
    * @returns true if the thing is a member of the class.
    */
   isMemberOf(t: Thing, c: Thing): boolean {
-    return this.getRelated(t, MEMBER_OF).has(c);
+    return this._getRelated(t, MEMBER_OF).has(c);
   }
 
   /**
@@ -610,16 +610,25 @@ export class HQDMModel {
 
   /**
    * Fetch all the Things related to this Thing by a predicate.
+   * This private method returns a TSet so that we can use the TSet.has() method elsewhere.
    *
    * @param t the first thing in the relationship.
    * @param predicate the predicate to search for.
    * @returns a TSet of the results.
    */
-  /* XXX This returns a 'live' result. Should we copy it instead? In
-   * which case we would probably want a non-copied method for internal
-   * use. */
-  getRelated(t: Thing, predicate: string): TSet<Thing> {
+  private _getRelated(t: Thing, predicate: string): TSet<Thing> {
     return this.things.get(t.id)?.get(predicate) ?? EMPTY;
+  }
+
+  /**
+   * Fetch all the Things related to this Thing by a predicate.
+   *
+   * @param t the first thing in the relationship.
+   * @param predicate the predicate to search for.
+   * @returns a TSet of the results.
+   */
+  getRelated(t: Thing, predicate: string): Iterable<Thing> {
+    return this.things.get(t.id)?.get(predicate) ?? [];
   }
 
   /**

--- a/src/TSet.ts
+++ b/src/TSet.ts
@@ -1,6 +1,6 @@
 /**
  * TSet and Eq are used to get around the limitations of TypeScript's built-in Set
- * which doesn't have well defined equality semantics, or  at least the semantics
+ * which doesn't have well defined equality semantics, or at least the semantics
  * needed for this application
  */
 
@@ -14,11 +14,20 @@ export interface Eq<T> {
 /**
  * TSet is a set of Ts that implements the Eq interface.
  */
-export class TSet<T extends Eq<T>> {
+export class TSet<T extends Eq<T>> implements Iterable<T> {
   private _data: T[] = [];
 
   constructor(ts: T[]) {
     ts.forEach((t) => this.add(t));
+  }
+
+  /**
+   * Returns an iterator for the underlying data.
+   *
+   * @returns An iterator for the underlying data.
+   */
+  [Symbol.iterator](): Iterator<T, any, undefined> {
+    return this._data[Symbol.iterator]();
   }
 
   /**

--- a/test/HQDM.test.ts
+++ b/test/HQDM.test.ts
@@ -131,8 +131,18 @@ describe('HQDMModel', () => {
       model.ending(s, activityTo);
     });
 
-    expect(model.memberOfKind(stateOfTeacher).size).to.equal(3);
-    expect(model.memberOfKind(stateOfStudent).size).to.equal(3);
+    let teacherCount = 0;
+    for(const _ of model.memberOfKind(stateOfTeacher)) {
+      teacherCount++;
+    }
+    expect(teacherCount).to.equal(3);
+
+    let studentCount = 0;
+    for(const _ of model.memberOfKind(stateOfStudent)) {
+      studentCount++;
+    }
+    expect(studentCount).to.equal(3);
+
     const ttl = model.save({
       hqdm: 'http://hqdm.com/',
       test: 'http://test.com/',

--- a/test/HQDM.test.ts
+++ b/test/HQDM.test.ts
@@ -131,17 +131,8 @@ describe('HQDMModel', () => {
       model.ending(s, activityTo);
     });
 
-    let teacherCount = 0;
-    for(const _ of model.memberOfKind(stateOfTeacher)) {
-      teacherCount++;
-    }
-    expect(teacherCount).to.equal(3);
-
-    let studentCount = 0;
-    for(const _ of model.memberOfKind(stateOfStudent)) {
-      studentCount++;
-    }
-    expect(studentCount).to.equal(3);
+    expect(model.memberOfKind(stateOfTeacher).size).to.equal(3);
+    expect(model.memberOfKind(stateOfStudent).size).to.equal(3);
 
     const ttl = model.save({
       hqdm: 'http://hqdm.com/',

--- a/test/TSet.test.ts
+++ b/test/TSet.test.ts
@@ -83,4 +83,17 @@ describe('TSet', () => {
     expect(s.has(t3)).to.be.true;
     expect(s.size).to.equal(2);
   });
+
+  it('Can iterate over a TSet', () => {
+    const s = new TSet<Thing>([
+      new Thing('one'),
+      new Thing('two'),
+      new Thing('three'),
+    ]);
+
+    for(const t of s) {
+      expect(s.has(t)).to.be.true;
+    }
+  });
+
 });


### PR DESCRIPTION
I did this in two places rather than just doing it in `getRelated()` since in some cases the TSet isn't returned outside the HQDM class so the clone would serve no purpose.