### PR TITLE
Implement the part_of relation on activities.

### DIFF
--- a/src/HQDM.ts
+++ b/src/HQDM.ts
@@ -54,6 +54,7 @@ export const HQDM_NS = 'https://hqdmtop.github.io/hqdm#';
 export const ENTITY_NAME = HQDM_NS + 'data_EntityName';
 export const CONSISTS_OF = HQDM_NS + 'consists_of';
 export const CONSISTS_OF_ = HQDM_NS + 'consists_of_';
+export const PART_OF = HQDM_NS + 'part_of';
 export const PART_OF_BY_CLASS = HQDM_NS + 'part_of_by_class';
 export const REPRESENTS = HQDM_NS + 'represents';
 export const CONSISTS_OF_BY_CLASS = HQDM_NS + 'consists_of_by_class';
@@ -162,6 +163,16 @@ export class HQDMModel {
       ?.map((p) => p.l)
       ?.forEach((p) => result.push(p));
     return new TSet(result);
+  }
+
+  /**
+   * Get the activities this one is part of.
+   *
+   * @param t An activity to get the parent of.
+   * @returns A TSet of the activities this one is part of.
+   */
+  getPartOf(t: Thing): TSet<Thing> {
+    return this.getRelated(t, PART_OF);
   }
 
   /**
@@ -686,6 +697,16 @@ export class HQDMModel {
    */
   addAsTemporalPartOf(part: Thing, whole: Thing): void {
     this.relate(TEMPORAL_PART_OF, part, whole);
+  }
+
+  /**
+   * Add an activity to a parent activity.
+   *
+   * @param part The sub-activity.
+   * @param whole The parent activity.
+   */
+  addPartOf(part: Thing, whole: Thing): void {
+    this.relate(PART_OF, part, whole);
   }
 
   /**

--- a/src/HQDM.ts
+++ b/src/HQDM.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable max-classes-per-file */
-import { Eq, TSet } from './TSet.js';
+import { Eq, Maybe, TSet } from './TSet.js';
 import * as N3 from 'n3';
 import { v4 as uuidv4, v5 as uuidv5 } from 'uuid';
 import { Readable } from 'readable-stream';
@@ -102,7 +102,7 @@ export class HQDMModel {
    * @kind the type of object to find.
    * @returns the object if found, undefined otherwise.
    */
-  findByEntityName(name: string, kind: Thing): Thing | undefined {
+  findByEntityName(name: string, kind: Thing): Maybe<Thing> {
     return this.relations
       .get(ENTITY_NAME)
       ?.filter((p) => this.isKindOf(p.l, kind))
@@ -181,7 +181,7 @@ export class HQDMModel {
    * @param t the thing to get the whole for.
    * @returns the whole if the thing is a temporal part, undefined otherwise.
    */
-  getTemporalWhole(t: Thing): Thing | undefined {
+  getTemporalWhole(t: Thing): Maybe<Thing> {
     return this.relations.get(TEMPORAL_PART_OF)?.first((p) => p.l.equal(t))?.r;
   }
 
@@ -755,7 +755,7 @@ export class HQDMModel {
    * @param t the thing to get the beginning event of.
    * @returns the beginning event or undefined.
    */
-  getBeginning(t: Thing): Thing | undefined {
+  getBeginning(t: Thing): Maybe<Thing> {
     return this.things
       .get(t.id)
       ?.get(BEGINNING)
@@ -768,7 +768,7 @@ export class HQDMModel {
    * @param t the thing to get the ending event of.
    * @returns the ending event or undefined.
    */
-  getEnding(t: Thing): Thing | undefined {
+  getEnding(t: Thing): Maybe<Thing> {
     return this.things
       .get(t.id)
       ?.get(ENDING)

--- a/src/TSet.ts
+++ b/src/TSet.ts
@@ -4,6 +4,8 @@
  * needed for this application
  */
 
+import type { Maybe } from './util';
+
 /**
  * Eq is an interface that defines the equality semantics for a type.
  */
@@ -36,7 +38,7 @@ export class TSet<T extends Eq<T>> implements Iterable<T> {
    * @returns A new TSet that is a copy of this TSet.
    */
   clone(): TSet<T> {
-    return this.map((t) => t);
+    return new TSet(this._data);
   }
 
   /**
@@ -93,7 +95,7 @@ export class TSet<T extends Eq<T>> implements Iterable<T> {
    * @param f The predicate function.
    * @returns The first T in the set that satisfies the predicate or undefined.
    */
-  first(f: (r: T) => boolean): T | undefined {
+  first(f: (r: T) => boolean): Maybe<T> {
     for (const t of this._data) {
       const result = f(t);
       if (result) {
@@ -101,6 +103,17 @@ export class TSet<T extends Eq<T>> implements Iterable<T> {
       }
     }
     return undefined;
+  }
+
+  /**
+   * Returns the only T in the set. Returns undefined if the set is
+   * empty. Throws if the set has more than one member.
+   */
+  only(): Maybe<T> {
+    if (this.size > 1) {
+      throw new Error(`TSet.only: set has ${this.size} members`);
+    }
+    return this._data[0];
   }
 
   /**

--- a/src/TSet.ts
+++ b/src/TSet.ts
@@ -4,7 +4,7 @@
  * needed for this application
  */
 
-import type { Maybe } from './util';
+export type Maybe<T> = T | undefined;
 
 /**
  * Eq is an interface that defines the equality semantics for a type.

--- a/src/TSet.ts
+++ b/src/TSet.ts
@@ -95,7 +95,8 @@ export class TSet<T extends Eq<T>> implements Iterable<T> {
    * @param f The predicate function.
    * @returns The first T in the set that satisfies the predicate or undefined.
    */
-  first(f: (r: T) => boolean): Maybe<T> {
+  first(f?: (r: T) => boolean): Maybe<T> {
+    f ??= _ => true;
     for (const t of this._data) {
       const result = f(t);
       if (result) {
@@ -103,17 +104,6 @@ export class TSet<T extends Eq<T>> implements Iterable<T> {
       }
     }
     return undefined;
-  }
-
-  /**
-   * Returns the only T in the set. Returns undefined if the set is
-   * empty. Throws if the set has more than one member.
-   */
-  only(): Maybe<T> {
-    if (this.size > 1) {
-      throw new Error(`TSet.only: set has ${this.size} members`);
-    }
-    return this._data[0];
   }
 
   /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,5 @@
+/**
+ * Utility classes and types.
+ */
+
+export type Maybe<T> = T | undefined;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,0 @@
-/**
- * Utility classes and types.
- */
-
-export type Maybe<T> = T | undefined;

--- a/test/TSet.test.ts
+++ b/test/TSet.test.ts
@@ -21,6 +21,19 @@ describe('TSet', () => {
     expect(s.size).to.equal(2);
   });
 
+  it('Can verify it contains a single value', () => {
+    const t1 = new Thing("one");
+    const t2 = new Thing("two");
+
+    const s0 = new TSet<Thing>([]);
+    const s1 = new TSet<Thing>([t1]);
+    const s2 = new TSet<Thing>([t1, t2]);
+
+    expect(s0.only()).to.be.undefined;
+    expect(s1.only()).to.equal(t1);
+    expect(() => s2.only()).to.throw();
+  });
+
   it('Can map a set of things to a set of other things', () => {
     const s = new TSet<Thing>([]);
 


### PR DESCRIPTION
This also implements an `only` method on TSets, which is useful now all HQDM methods are returning TSets.