### PR TITLE
Fix problems with `npm run test`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules
 
 .idea
 
+# Vim swap
+*.swp
+
 src/Scratch*
 dist
 .vscode/

--- a/src/TSet.ts
+++ b/src/TSet.ts
@@ -96,9 +96,9 @@ export class TSet<T extends Eq<T>> implements Iterable<T> {
    * @returns The first T in the set that satisfies the predicate or undefined.
    */
   first(f?: (r: T) => boolean): Maybe<T> {
-    f ??= _ => true;
+    const pred = f ?? (() => true);
     for (const t of this._data) {
-      const result = f(t);
+      const result = pred(t);
       if (result) {
         return t;
       }

--- a/test/TSet.test.ts
+++ b/test/TSet.test.ts
@@ -21,19 +21,6 @@ describe('TSet', () => {
     expect(s.size).to.equal(2);
   });
 
-  it('Can verify it contains a single value', () => {
-    const t1 = new Thing("one");
-    const t2 = new Thing("two");
-
-    const s0 = new TSet<Thing>([]);
-    const s1 = new TSet<Thing>([t1]);
-    const s2 = new TSet<Thing>([t1, t2]);
-
-    expect(s0.only()).to.be.undefined;
-    expect(s1.only()).to.equal(t1);
-    expect(() => s2.only()).to.throw();
-  });
-
   it('Can map a set of things to a set of other things', () => {
     const s = new TSet<Thing>([]);
 


### PR DESCRIPTION
Adjust code to keep ESLint happy.

Remove a now-redundant test.