### PR TITLE
Include version info in the RDF.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 test*
+src/version.ts

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 *.swp
 
 src/Scratch*
+src/version.ts
 dist
 .vscode/
 coverage/

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "prebuild":  "node -p \"'export const HQDM_LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "build": "tsc",
     "doc": "typedoc src/*.ts",
+    "prelint": "npm run prebuild",
     "lint": "eslint . --ext .ts",
     "prepare": "npm test"
   },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "version": "git add -A .",
     "pretest": "npm run lint && npm run build",
     "preversion": "npm run lint && npm run doc && npm run build",
+    "prebuild":  "node -p \"'export const HQDM_LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "build": "tsc",
     "doc": "typedoc src/*.ts",
     "lint": "eslint . --ext .ts",

--- a/src/HQDM.ts
+++ b/src/HQDM.ts
@@ -111,6 +111,9 @@ export class HQDMModel {
    * Ensure output files include a given owl:versionInfo triple. This
    * will remove any existing version triple for this subject.
    *
+   * This method may be removed in future. It does not properly belong
+   * in an HQDM data store, but at a lower level.
+   *
    * @param subject The subject IRI of the triple.
    * @param version The version number to write as the object.
    */
@@ -125,6 +128,9 @@ export class HQDMModel {
   /**
    * Check if we have a given owl:versionInfo triple. This may have been
    * created with setVersionInfo or loaded from a file.
+   *
+   * This method may be removed in future. It does not properly belong
+   * in an HQDM data store, but at a lower level.
    *
    * @param subject The subject IRI to look for.
    * @returns The version string found, or undefined.
@@ -144,6 +150,15 @@ export class HQDMModel {
     this.setVersionInfo(HQDM_LIB_NS, HQDM_LIB_VERSION);
   }
 
+  /**
+   * Go through all relations in the datastore and replace one IRI
+   * prefix with another. Changing IRI prefixes known to hqdm-lib may
+   * cause data corruption; this is intended for forward-porting user
+   * object identifiers in situations where IRI prefixes have changed.
+   *
+   * This method may be removed in future. It does not properly belong
+   * in an HQDM data store, but at a lower level.
+   */
   replaceIriPrefix(from: string, to: string) {
     const doReplace = (str: string) =>
       str.startsWith(from) ? str.replace(from, to) : str;

--- a/src/HQDM.ts
+++ b/src/HQDM.ts
@@ -144,6 +144,32 @@ export class HQDMModel {
     this.setVersionInfo(HQDM_LIB_NS, HQDM_LIB_VERSION);
   }
 
+  replaceIriPrefix(from: string, to: string) {
+    const doReplace = (str: string) =>
+      str.startsWith(from) ? str.replace(from, to) : str;
+
+    const newThings = new Map<string, Map<string, TSet<Thing>>>();
+    this.things.forEach((preds: Map<string, TSet<Thing>>, first: string) => {
+      const newFirst = doReplace(first);
+      const newPreds = new Map<string, TSet<Thing>>();
+      preds.forEach((seconds: TSet<Thing>, pred: string) =>
+        newPreds.set(doReplace(pred), 
+          seconds.map((t: Thing) => new Thing(doReplace(t.id)))));
+      newThings.set(newFirst, newPreds);
+    });
+    this.things = newThings;
+
+    const newRelations = new Map<string, TSet<Pair<Thing, Thing>>>;
+    this.relations.forEach((pairs: TSet<Pair<Thing, Thing>>, pred: string) => {
+      newRelations.set(doReplace(pred),
+        pairs.map((pair: Pair<Thing, Thing>) =>
+          new Pair<Thing, Thing>(
+            new Thing(doReplace(pair.l.id)), 
+            new Thing(doReplace(pair.r.id)))));
+    });
+    this.relations = newRelations;
+  }
+
   /**
    * Check if there is a thing with the given id.
    *

--- a/src/HQDM.ts
+++ b/src/HQDM.ts
@@ -81,7 +81,7 @@ export const ENDING = HQDM_NS + 'ending';
  * number. The version is represented in the external RDF as a triple
  * subject HQDM_LIB_REPR and predicate OWL_VERSION.
  */
-const currentReprVersion = "1";
+const currentReprVersion = '1';
 
 /**
  * Predicates to represent in the RDF with literals.
@@ -153,18 +153,18 @@ export class HQDMModel {
       const newFirst = doReplace(first);
       const newPreds = new Map<string, TSet<Thing>>();
       preds.forEach((seconds: TSet<Thing>, pred: string) =>
-        newPreds.set(doReplace(pred), 
+        newPreds.set(doReplace(pred),
           seconds.map((t: Thing) => new Thing(doReplace(t.id)))));
       newThings.set(newFirst, newPreds);
     });
     this.things = newThings;
 
-    const newRelations = new Map<string, TSet<Pair<Thing, Thing>>>;
+    const newRelations = new Map<string, TSet<Pair<Thing, Thing>>>();
     this.relations.forEach((pairs: TSet<Pair<Thing, Thing>>, pred: string) => {
       newRelations.set(doReplace(pred),
         pairs.map((pair: Pair<Thing, Thing>) =>
           new Pair<Thing, Thing>(
-            new Thing(doReplace(pair.l.id)), 
+            new Thing(doReplace(pair.l.id)),
             new Thing(doReplace(pair.r.id)))));
     });
     this.relations = newRelations;
@@ -563,7 +563,7 @@ export class HQDMModel {
     const input = new Readable({
       objectMode: true,
       read: () => {
-        quads.forEach(q => input.push(q));
+        quads.forEach((q) => input.push(q));
         input.push(null);
       },
     });
@@ -682,20 +682,20 @@ export class HQDMModel {
    * @param second the second thing.
    */
   unrelate(predicate: string, first: Thing, second: Thing): void {
-    let predicates = this.things.get(first.id);
+    const predicates = this.things.get(first.id);
     if (!predicates) {
       return;
     }
 
-    let relations = predicates?.get(predicate);
+    const relations = predicates?.get(predicate);
     if (!relations) {
       return;
     }
     relations.remove(second);
 
-    let pairs = this.relations.get(predicate);
+    const pairs = this.relations.get(predicate);
     if (!pairs) {
-      throw new Error(`Internal inconsistency detected!`);
+      throw new Error('Internal inconsistency detected!');
     }
     pairs.remove(new Pair(first, second));
   }
@@ -899,7 +899,7 @@ export class HQDMModel {
     try {
       const quads = parser.parse(ttl);
 
-      let ver = quads
+      const ver = quads
         .find((q: N3.Quad) =>
           q.subject.value === HQDM_LIB_REPR &&
           q.predicate.value === OWL_VERSION)
@@ -907,7 +907,7 @@ export class HQDMModel {
 
       /* For now assume unversioned RDF is the current version */
       if (ver !== undefined && ver !== currentReprVersion) {
-        throw new Error(`RDF uses an unknown data representation`);
+        throw new Error('RDF uses an unknown data representation');
       }
 
       quads.forEach((q) => {

--- a/src/HQDM.ts
+++ b/src/HQDM.ts
@@ -607,6 +607,32 @@ export class HQDMModel {
   }
 
   /**
+   * Remove a relation.
+   *
+   * @param predicate the predicate of the relation.
+   * @param first the first thing in the relationship.
+   * @param second the second thing.
+   */
+  unrelate(predicate: string, first: Thing, second: Thing): void {
+    let predicates = this.things.get(first.id);
+    if (!predicates) {
+      return;
+    }
+
+    let relations = predicates?.get(predicate);
+    if (!relations) {
+      return;
+    }
+    relations.remove(second);
+
+    let pairs = this.relations.get(predicate);
+    if (!pairs) {
+      throw new Error(`Internal inconsistency detected!`);
+    }
+    pairs.remove(new Pair(first, second));
+  }
+
+  /**
    * Check if two things are related by a predicate.
    *
    * @param predicate the predicate to check.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './HQDM.js';
 export * from './TSet.js';
+export * from './version.js';


### PR DESCRIPTION
* Define an IRI namespace to use for this library.
* Make generated RDF include both the version of the library and a version for the HQDM->RDF mapping.
* Allow clients to include more version numbers, and retrieve them from loaded RDF.
* Add a method to remap an IRI prefix, for fixing up old files.
* Sort quads on output.

For now assume unversioned RDF is compatible with version 1. This may want revisiting in the future.